### PR TITLE
update notes about default_cache_behavior

### DIFF
--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -226,7 +226,7 @@ of several sub-resources - these resources are laid out below.
 
 The arguments for `default_cache_behavior` are the same as for
 [`cache_behavior`](#cache-behavior-arguments), except for the `path_pattern`
-argument is not required.
+argument is omitted.
 
 #### Logging Config Arguments
 


### PR DESCRIPTION
When declaring the default_cache_behavior resource, path_pattern must not be set.  Attempting to set it will cause a plan to fail:
- aws_cloudfront_distribution.sproutsocial_com: default_cache_behavior.0: invalid or unknown key: path_pattern
